### PR TITLE
画像投稿時のプレビュー機能実装

### DIFF
--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -33,4 +33,6 @@ const pay = () => {
   });
 };
 
-window.addEventListener("load", pay);
+if (document.URL.match( /purchases/ )) {
+  window.addEventListener("load", pay);
+};

--- a/app/javascript/fee.js
+++ b/app/javascript/fee.js
@@ -19,4 +19,6 @@ function calc (){
   })
 }
 
-window.addEventListener('load', calc)
+if ( document.getElementById("item-price") != null) {
+window.addEventListener('load', calc);
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,7 @@ require("@rails/activestorage").start()
 require("channels")
 require("../fee")
 require("../card")
+require("../preview")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -1,0 +1,25 @@
+if (document.URL.match( /new/ ) || document.URL.match( /edit/ )) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const ImageList = document.getElementById('image-list');
+    
+    const createImageHTML = (blob) => {
+      const imageElement = document.createElement('div');
+      const blobImage = document.createElement('img');
+      blobImage.setAttribute('src', blob);
+      imageElement.appendChild(blobImage);
+      ImageList.appendChild(imageElement);
+    };
+    
+    document.getElementById('item-image').addEventListener('change', (e) => {
+      const imageContent = document.querySelector('img');
+      if (imageContent){
+        imageContent.remove();
+      }
+
+    const file = e.target.files[0];
+    const blob = window.URL.createObjectURL(file);
+    
+    createImageHTML(blob);
+    });
+  });
+};

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -21,6 +21,7 @@
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
+    <div id="image-list"></div>
 
     <div class="new-items">
       <div class="weight-bold-text">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -21,6 +21,7 @@
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
+    <div id="image-list"></div>
 
     <div class="new-items">
       <div class="weight-bold-text">


### PR DESCRIPTION
# What
画像投稿時のプレビュー機能実装

# Why
画像投稿・編集時にプレビュー機能を実装することで、投降する画像の確認をすることができるようにするため。
また、JavaScriptの読み込みが不要なページでは読み込まないようにし、コンソール上にエラーが表示されることを回避する。