### PR TITLE
エラーメッセージの日本語化実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem 'aws-sdk-s3', require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.6)
       actionpack (= 6.0.3.6)
       activesupport (= 6.0.3.6)
@@ -362,6 +365,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     validates :images
   end
 
-  with_options numericality: { other_than: 1, message: 'please select other than "---"' } do
+  with_options numericality: { other_than: 1, message: 'を選択してください' } do
     validates :category_id
     validates :status_id
     validates :payment_id
@@ -24,10 +24,10 @@ class Item < ApplicationRecord
     validates :delivery_day_id
   end
 
-  validates :price, numericality: { with: /\A[0-9]+\z/, message: 'only half-width numbers can be entered' }, if: proc { |item|
+  validates :price, numericality: { with: /\A[0-9]+\z/, message: 'は半角数字のみ入力できます' }, if: proc { |item|
                                                                                                                    item.price.present?
                                                                                                                  }
   validates :price, numericality: {
-    greater_than_or_equal_to: 300, less_than: 10_000_000, message: 'out of the numerical range'
+    greater_than_or_equal_to: 300, less_than: 10_000_000, message: 'が入力範囲外です'
   }, if: proc { |item| item.price.present? }
 end

--- a/app/models/purchase_address.rb
+++ b/app/models/purchase_address.rb
@@ -12,13 +12,13 @@ class PurchaseAddress
     validates :tel
   end
 
-  validates :prefecture_id, numericality: { other_than: 1, message: 'please select other than "---"' }
+  validates :prefecture_id, numericality: { other_than: 1, message: 'を選択してください' }
 
-  validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'requires "-"' }, if: proc { |purchase_address|
+  validates :postal_code, format: { with: /\A\d{3}-\d{4}\z/, message: 'はハイフン(-)を含む半角数字7桁で入力してください' }, if: proc { |purchase_address|
                                                                                               purchase_address.postal_code.present?
                                                                                             }
 
-  validates :tel, numericality: { only_integer: true, message: 'only half-width numbers can be entered' }, if: proc { |purchase_address|
+  validates :tel, numericality: { only_integer: true, message: '半角数字のみで入力してください' }, if: proc { |purchase_address|
                                                                                                                  purchase_address.tel.present?
                                                                                                                }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,19 +17,18 @@ class User < ApplicationRecord
     validates :read_first_name
     validates :birthday
   end
-  validates :password, format: { with: PASSWORD_REGEX, message: 'Use both English and numbers' }, if: proc { |user|
-                                                                                                        user.password.present?
-                                                                                                      }
-  validates :read_last_name, format: { with: KANA_REGEX, message: 'Please enter in the full-width katakana' }, if: proc { |user|
-                                                                                                                     user.read_last_name.present?
-                                                                                                                   }
-  validates :read_first_name, format: { with: KANA_REGEX, message: 'Please enter in the full-width katakana' }, if: proc { |user|
-                                                                                                                      user.read_first_name.present?
-                                                                                                                    }
-  validates :last_name, format: { with: NAME_REGEX, message: 'Please enter full-width Japanese' }, if: proc { |user|
-                                                                                                         user.last_name.present?
-                                                                                                       }
-  validates :first_name, format: { with: NAME_REGEX, message: 'Please enter full-width Japanese' }, if: proc { |user|
-                                                                                                          user.first_name.present?
-                                                                                                        }
+
+  validates :password, format: { with: PASSWORD_REGEX, message: 'は半角英数字の組合せで入力してください' }, if: proc { |user|user.password.present?}
+
+  with_options format: { with: KANA_REGEX, message: 'は全角カタカナで入力してください' } do
+    validates :read_last_name, if: proc { |user|user.read_last_name.present?}
+
+    validates :read_first_name, if: proc { |user|user.read_first_name.present?}
+  end
+
+  with_options format: { with: NAME_REGEX, message: 'は全角日本語で入力してください' } do
+    validates :last_name, if: proc { |user|user.last_name.present?}
+
+    validates :first_name, if: proc { |user|user.first_name.present?}
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima35193
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+ja:
+ activerecord:
+   attributes:
+     user:
+       nickname: ニックネーム
+       last_name: お名前(姓)
+       first_name: お名前(名)
+       read_last_name: お名前カナ(姓)
+       read_first_name: お名前カナ(名)
+       birthday: 生年月日
+     item:
+       name: 商品名
+       description: 商品の説明
+       price: 価格
+       images: 画像
+       category_id: カテゴリー
+       status_id: 商品の状態
+       payment_id: 発送料の負担
+       prefecture_id: 発送元の地域
+       delivery_day_id: 発送までの日数
+ activemodel:
+   attributes:
+     purchase_address:
+       token: クレジットカード情報
+       postal_code: 郵便番号
+       city: 市区町村
+       address: 番地
+       tel: 電話番号
+       prefecture_id: 都道府県

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
+      item.images.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Item, type: :model do
     end
 
     context '商品登録できる場合' do
-      it 'name,description,price,image,category,status,payment,prefecture,delivery_dayが正しく入力されていれば登録できること' do
+      it 'name,description,price,images,category,status,payment,prefecture,delivery_dayが正しく入力されていれば登録できること' do
         expect(@item).to be_valid
       end
 
@@ -44,61 +44,61 @@ RSpec.describe Item, type: :model do
       it 'priceが299以下では登録できないこと' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price out of the numerical range')
+        expect(@item.errors.full_messages).to include('Price が入力範囲外です')
       end
 
       it 'priceが10,000,000以上では登録できないこと' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price out of the numerical range')
+        expect(@item.errors.full_messages).to include('Price が入力範囲外です')
       end
 
       it 'priceに全角が含まれていると登録できないこと' do
         @item.price = '2５00'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price only half-width numbers can be entered')
+        expect(@item.errors.full_messages).to include('Price は半角数字のみ入力できます')
       end
 
       it 'priceに数字以外が含まれていると登録できないこと' do
         @item.price = '2000yen'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price only half-width numbers can be entered')
+        expect(@item.errors.full_messages).to include('Price は半角数字のみ入力できます')
       end
 
-      it 'imageが空では登録できないこと' do
-        @item.image = nil
+      it 'imagesが空では登録できないこと' do
+        @item.images = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("Images can't be blank")
       end
 
       it 'category_idが1では登録できないこと' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category please select other than "---"')
+        expect(@item.errors.full_messages).to include('Category を選択してください')
       end
 
       it 'status_idが1では登録できないこと' do
         @item.status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Status please select other than "---"')
+        expect(@item.errors.full_messages).to include('Status を選択してください')
       end
 
       it 'payment_idが1では登録できないこと' do
         @item.payment_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Payment please select other than "---"')
+        expect(@item.errors.full_messages).to include('Payment を選択してください')
       end
 
       it 'prefecture_idが1では登録できないこと' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Prefecture please select other than "---"')
+        expect(@item.errors.full_messages).to include('Prefecture を選択してください')
       end
 
       it 'delivery_day_idが1では登録できないこと' do
         @item.delivery_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Delivery day please select other than "---"')
+        expect(@item.errors.full_messages).to include('Delivery day を選択してください')
       end
     end
   end

--- a/spec/models/purchase_address_spec.rb
+++ b/spec/models/purchase_address_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PurchaseAddress, type: :model do
     before do
       @user = FactoryBot.create(:user)
       @item = FactoryBot.create(:item)
-      sleep(0.01)
+      sleep(0.08)
       @purchase_address = FactoryBot.build(:purchase_address)
       @purchase_address.user_id = @user.id
       @purchase_address.item_id = @item.id
@@ -55,13 +55,13 @@ RSpec.describe PurchaseAddress, type: :model do
       it 'postal_codeにハイフンがなくては登録できないこと' do
         @purchase_address.postal_code = '1234444'
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include('Postal code requires "-"')
+        expect(@purchase_address.errors.full_messages).to include('Postal code はハイフン(-)を含む半角数字7桁で入力してください')
       end
 
       it 'postal_codeが3文字-4文字でなくては登録できないこと' do
         @purchase_address.postal_code = '1234-444'
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include('Postal code requires "-"')
+        expect(@purchase_address.errors.full_messages).to include('Postal code はハイフン(-)を含む半角数字7桁で入力してください')
       end
 
       it 'cityが空では登録できないこと' do
@@ -91,19 +91,19 @@ RSpec.describe PurchaseAddress, type: :model do
       it 'telに全角数字が含まれていると登録できないこと' do
         @purchase_address.tel = '12３45６78９'
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include('Tel only half-width numbers can be entered')
+        expect(@purchase_address.errors.full_messages).to include('Tel 半角数字のみで入力してください')
       end
 
       it 'telに数字以外が含まれていると登録できないこと' do
         @purchase_address.tel = '12as4455'
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include('Tel only half-width numbers can be entered')
+        expect(@purchase_address.errors.full_messages).to include('Tel 半角数字のみで入力してください')
       end
 
       it 'prefecture_idが1では登録できないこと' do
         @purchase_address.prefecture_id = 1
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include('Prefecture please select other than "---"')
+        expect(@purchase_address.errors.full_messages).to include('Prefecture を選択してください')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,21 +103,21 @@ RSpec.describe User, type: :model do
         @user.password = '123456'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Use both English and numbers')
+        expect(@user.errors.full_messages).to include('Password は半角英数字の組合せで入力してください')
       end
 
       it 'passwordが英字のみでは登録できないこと' do
         @user.password = 'abcdef'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Use both English and numbers')
+        expect(@user.errors.full_messages).to include('Password は半角英数字の組合せで入力してください')
       end
 
       it 'passwordに全角が含まれると登録できないこと' do
         @user.password = 'abｚ123'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password Use both English and numbers')
+        expect(@user.errors.full_messages).to include('Password は半角英数字の組合せで入力してください')
       end
 
       it 'passwordとpassword_confirmationが不一致では登録できないこと' do
@@ -130,25 +130,25 @@ RSpec.describe User, type: :model do
       it 'last_nameに半角文字があれば登録できないこと' do
         @user.last_name = 'あｱ漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name Please enter full-width Japanese')
+        expect(@user.errors.full_messages).to include('Last name は全角日本語で入力してください')
       end
 
       it 'first_nameに半角文字があれば登録できないこと' do
         @user.first_name = 'あｱ漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name Please enter full-width Japanese')
+        expect(@user.errors.full_messages).to include('First name は全角日本語で入力してください')
       end
 
       it 'read_last_nameに全角カタカナ意外があれば登録できないこと' do
         @user.read_last_name = 'かなカナ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Read last name Please enter in the full-width katakana')
+        expect(@user.errors.full_messages).to include('Read last name は全角カタカナで入力してください')
       end
 
       it 'read_first_nameに全角カタカナ意外があれば登録できないこと' do
         @user.read_first_name = 'かなカナ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Read first name Please enter in the full-width katakana')
+        expect(@user.errors.full_messages).to include('Read first name は全角カタカナで入力してください')
       end
 
       it 'emailは先頭が@では登録でないこと' do


### PR DESCRIPTION
# What
エラーメッセージの日本語化実装
# Why
ユーザーを日本の方が多いと想定し、エラーメッセージを日本語表記にする事でわかりやすくするため。